### PR TITLE
Corrigido caminho para o head das páginas ejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const app = express()
 const PORT = process.env.PORT
 
 app.set("view engine", "ejs")
-app.set("head", "views/partials")
 
 app.use("/", require("./routes/helloworld").router)
 app.use("/", require("./routes/autarquia-routes").router)

--- a/views/autarquia/cadIES.ejs
+++ b/views/autarquia/cadIES.ejs
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 
 <head>
-    <%- include('../partials/head.ejs') %>
+    <%- include(process.cwd() + '/views/partials/head.ejs') %>
 </head>
 
 <body>

--- a/views/autarquia/cadLocalEstagio.ejs
+++ b/views/autarquia/cadLocalEstagio.ejs
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 
 <head>
-    <%- include('../partials/head.ejs') %>
+    <%- include(process.cwd() + '/views/partials/head.ejs') %>
 </head>
 
 <body>

--- a/views/base.ejs
+++ b/views/base.ejs
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 
 <head>
-    <%- include("/partials/head.ejs") %>
+    <%- include(process.cwd() + '/views/partials/head.ejs') %>
 </head>
 
 <body>

--- a/views/campoEstagio/atualizarVagas/LocalEstagio.ejs
+++ b/views/campoEstagio/atualizarVagas/LocalEstagio.ejs
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 
 <head>
-    <%- include('../partials/head.ejs') %>
+    <%- include(process.cwd() + '/views/partials/head.ejs') %>
 </head>
 
 <body>

--- a/views/instituicao/preencherFicha/preencherFicha.ejs
+++ b/views/instituicao/preencherFicha/preencherFicha.ejs
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 
 <head>
-    <%- include('../partials/head.ejs') %>
+    <%- include(process.cwd() + '/views/partials/head.ejs') %>
 </head>
 
 <body>

--- a/views/login/login.ejs
+++ b/views/login/login.ejs
@@ -2,8 +2,8 @@
 <html lang="pt-BR">
 
 <head>
-    <%- include('../partials/head.ejs') %>
-        <link rel="stylesheet" href="./login.css">
+    <%- include(process.cwd() + '/views/partials/head.ejs') %>
+    <link rel="stylesheet" href="./login.css">
 </head>
 
 <body>


### PR DESCRIPTION
A linha "<%- include(process.cwd() + '/views/partials/head.ejs') %>" é para adicionar a cabeça das páginas válida para qualquer página da aplicação.